### PR TITLE
rename host parameter to hostname and use it

### DIFF
--- a/lib/jasmine/base.rb
+++ b/lib/jasmine/base.rb
@@ -30,12 +30,12 @@ module Jasmine
     true
   end
 
-  def self.wait_for_listener(port, host = "localhost", seconds_to_wait = 20)
+  def self.wait_for_listener(port, hostname = "localhost", seconds_to_wait = 20)
     time_out_at = Time.now + seconds_to_wait
-    until server_is_listening_on "localhost", port
+    until server_is_listening_on hostname, port
       sleep 0.1
-      puts "Waiting for #{name} on #{port}..."
-      raise "jasmine server didn't show up on port #{port} after #{seconds_to_wait} seconds." if Time.now > time_out_at
+      puts "Waiting for server on #{hostname}:#{port}..."
+      raise "jasmine server didn't show up on port #{hostname}:#{port} after #{seconds_to_wait} seconds." if Time.now > time_out_at
     end
   end
 


### PR DESCRIPTION
in https://github.com/jasmine/jasmine-gem/commit/caeb57c43138852bf6e433c964d0c217b23f5005 we added the host parameter, but it wasn't used.  This PR uses it now.